### PR TITLE
Add new probot features worked on in Q2 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 # Camunda Community Hub Probot
 
-## The Camunda Community Hub Probot allows you to quickly add labels to issues by commenting and typing a slash command.
+## The Camunda Community Hub Probot allows you to quickly add labels to issues by commenting and typing a slash command, allows for maintainers to opt-in to automated release note drafting, and automatically applies a <code>triage</code> label to open issues or pull requests without any labels specified. 
 
-Usage: To add a label to an open issue, in the 'Leave a Comment' space enter the following:
+### Issue Labeling with Probot:
+
+To add a label to an open issue or pull request, in the 'Leave a Comment' space enter the following:
 
 ```
 /lm add label1, label2, label3
@@ -12,7 +14,24 @@ Usage: To add a label to an open issue, in the 'Leave a Comment' space enter the
 
 Once your comment is posted, after a few moments, the bot should apply the label you specified. To see the list of labels available to you in the Camunda Community Hub, please review our [steps for issue triage and labelling](https://github.com/camunda-community-hub/community/blob/main/issue-triage.md). For more information on extension lifecycles and how to implement them, please [read the documentation](https://github.com/camunda-community-hub/community/blob/main/extension-lifecycle.md).
 
+### Issue Triage 
+
 If you open an issue without a label, Probot will automatically assign the 'triage' label to your issue. Once an issue label is added, the triage label will be removed. If your issue has labels applied to it before submitting the issue, the 'triage' label will not be applied.
+
+### Automated Release Notes Drafting
+
+If you would like to opt-in to using [Release Drafter](https://github.com/release-drafter/release-drafter) to automate drafting of your extension's release notes, you can do so by doing the following:
+
+1. [Set a topic](https://docs.github.com/en/github/administering-a-repository/managing-repository-settings/classifying-your-repository-with-topics) in your repository to <code>release-drafter</code>.
+2. Add a label to an issue or PR that adheres to the Release Drafter specifications. These are <code>feature</code>, <code>fix</code>, and <code>chore</code>
+3. Once one of the above labels is added, the corresponding GitHub Action will run. When successful, you can click on 'Details' in the workflow to see the checks complete, or to debug any issues that arise.
+
+<img src="https://github.com/camunda-community-hub/camunda-community-hub-probot/blob/main/assets/Release%20Drafter%20Checks.png">
+
+To learn more about Release Drafter, we suggest [reading the official documentation](https://github.com/release-drafter/release-drafter).
+
+4. Currently, if a check fails, it must be re-run manually. We hope to automate this in the future.
+5. If you have no labels on a PR and you choose to merge it, it will not be included in the automated release notes.
 
 ## Setup
 


### PR DESCRIPTION
Added documentation surrounding issue triage label, release drafter, and screenshots of a successful check.

